### PR TITLE
Merge back from live to master

### DIFF
--- a/docfx.json
+++ b/docfx.json
@@ -163,10 +163,12 @@
       "feedback_system": "GitHub",
       "feedback_product_url": "https://github.com/microsoft/partner-center-powerShell/issues/new",
       "ms.author": "iswillia",
+      "manager": "jasonh",
       "ms.devlang": "powershell",
       "ms.prod": "partner-center",
       "showPowerShellPicker": "true",
-      "uhfHeaderId": "MSDocsHeader-Partner-Center"
+      "uhfHeaderId": "MSDocsHeader-Partner-Center",
+      "searchScope": ["Partner Center", "Partner Center developer resources","Partner Center PowerShell"] 
     },
     "dest": "partnercenterps",
     "markdownEngineName": "markdig"

--- a/docfx.json
+++ b/docfx.json
@@ -146,8 +146,8 @@
       },
       "ms.date": {
         "partnercenterps-1.5/**/*.md": "12/19/2019",
-        "partnercenterps-2.0/**/*.md": "01/10/2019",
-        "partnercenterps-3.0/**/*.md": "01/10/2019"
+        "partnercenterps-2.0/**/*.md": "01/10/2020",
+        "partnercenterps-3.0/**/*.md": "01/29/2020"
       },
       "ms.topic": {
         "docs-conceptual/**/*.md": "article",

--- a/docs-conceptual/partnercenterps-3.0/release-notes.md
+++ b/docs-conceptual/partnercenterps-3.0/release-notes.md
@@ -5,10 +5,24 @@ description: Discover what has changed with Partner Center PowerShell with each 
 
 # Release notes
 
+## 3.0.6 - January 2020
+
+* Authentication 
+  * Addressed issue [#268](https://github.com/microsoft/Partner-Center-PowerShell/issues/268) that was impacting the [New-PartnerAccessToken](https://docs.microsoft.com/powershell/module/partnercenter/New-PartnerAccessToken) command when trying to get an access token for Exchange Online with a refresh token
+* Agreements
+  * Addressed issue [#262](https://github.com/microsoft/Partner-Center-PowerShell/issues/262) that was preventing [Get-PartnerAgreementDocument](https://docs.microsoft.com/powershell/module/partnercenter/Get-PartnerAgreementDocument) from being invoked when the `Language` parameter was specified
+* Qualifications
+  * Addressed issue [#258](https://github.com/microsoft/Partner-Center-PowerShell/issues/258) with the [Set-PartnerCustomerQualification](https://docs.microsoft.com/powershell/module/partnercenter/Set-PartnerCustomerQualification) command that was preventing API exception information from being parsed as excepted
+
 ## 3.0.5 - January 2020
 
 * Authentication
   * Addressed issue [#254](https://github.com/microsoft/Partner-Center-PowerShell/issues/254) with the [New-PartnerAccessToken](https://docs.microsoft.com/powershell/module/partnercenter/New-PartnerAccessToken) where the Scope parameter was incorrectly being required
+  * Addressed an issue where NullReferenceException exception was being encountered when invoking [Connect-PartnerCenter](https://docs.microsoft.com/powershell/module/partnercenter/Connect-PartnerCenter) using a certificate
+  * Addressed an issue where NullReferenceException exception was being encountered when invoking [New-PartnerAccessToken](https://docs.microsoft.com/powershell/module/partnercenter/New-PartnerAccessToken) using a certificate
+  * Defined the refresh token parameter set for the [New-PartnerAccessToken](https://docs.microsoft.com/powershell/module/partnercenter/New-PartnerAccessToken) command to make it easier to ensure all the appropriate parameters have been specified when exchanging a refresh token for an access token
+* Module
+  * All commands now perform operations asynchronously
 
 ## 3.0.4 - January 2020
 

--- a/partnercenterps-3.0/PartnerCenter/New-PartnerAccessToken.md
+++ b/partnercenterps-3.0/PartnerCenter/New-PartnerAccessToken.md
@@ -47,8 +47,8 @@ New-PartnerAccessToken -ApplicationId <String> [-Environment <EnvironmentName>] 
 
 ### ByModule
 ```powershell
-New-PartnerAccessToken [-Environment <EnvironmentName>] -Module <ModuleName> [-Tenant <String>]
- [-UseAuthorizationCode] [<CommonParameters>]
+New-PartnerAccessToken [-Environment <EnvironmentName>] -Module <ModuleName> [-RefreshToken <String>]
+ [-Tenant <String>] [-UseAuthorizationCode] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -227,6 +227,18 @@ Parameter Sets: RefreshToken
 Aliases:
 
 Required: True
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+```yaml
+Type: String
+Parameter Sets: ByModule
+Aliases:
+
+Required: False
 Position: Named
 Default value: None
 Accept pipeline input: False


### PR DESCRIPTION
Hi @isaiahwilliams 

Looks like this repo is configured to let customers make changes on Live. I think it should be configured to edit on master instead of live. I'm trying to fix that in PR #124 but there's a build problem: https://github.com/MicrosoftDocs/partner-center-docs-powershell/pull/124

Since a couple of things have been changed in live, I was thinking we need to sync live to master. Please review in case it will cause problems. 

Thanks, Jason