### PR TITLE
Replace legacy build pipeline with PowerShell SDP build pipeline

### DIFF
--- a/.openpublishing.publish.config.json
+++ b/.openpublishing.publish.config.json
@@ -36,17 +36,17 @@
     {
       "path_to_root": "_themes",
       "url": "https://github.com/Microsoft/templates.docs.msft",
-      "branch": "develop",
+      "branch": "master",
       "branch_mapping": {}
     }
   ],
   "dependent_packages": [
     {
       "id": "Microsoft.DocAsCode.MAML2Yaml",
-      "nuget_feed": "https://www.myget.org/F/op-dev/api/v2",
+      "nuget_feed": "https://www.myget.org/F/op/api/v2",
       "path_to_root": "_dependentPackages/MAML2Yaml",
       "target_framework": "net45",
-      "version": "latest-prerelease"
+      "version": "latest"
     }
   ],
   "branch_target_mapping": {

--- a/.openpublishing.publish.config.json
+++ b/.openpublishing.publish.config.json
@@ -12,16 +12,14 @@
         "Conceptual": "Content",
         "ManagedReference": "Content",
         "RestApi": "Content",
-        "AzurePSModulePage": "Content"
+        "PowershellModule": "Content",
+        "PowershellCmdlet": "Content"
       },
       "build_entry_point": "docs",
       "template_folder": "_themes",
-      "customized_template_paths": [
-        "_dependentPackages/azurecli.plugins/azurecli"
-      ],
       "customized_tasks": {
         "docset_prebuild": [
-          "_dependentPackages/CommonPlugins/tools/PowerShellReference.ps1"
+          "_dependentPackages/MAML2Yaml/tools/Run.ps1"
         ]
       }
     }
@@ -38,23 +36,17 @@
     {
       "path_to_root": "_themes",
       "url": "https://github.com/Microsoft/templates.docs.msft",
-      "branch": "master",
+      "branch": "develop",
       "branch_mapping": {}
     }
   ],
   "dependent_packages": [
     {
-      "path_to_root": "_dependentPackages/azurecli.plugins",
-      "id": "opbuild.templates.azurecli",
-      "version": "latest",
-      "nuget_feed": "https://www.myget.org/F/op/api/v2"
-    },
-    {
-      "id": "Microsoft.OpenPublishing.CommonPlugins",
-      "nuget_feed": "https://www.myget.org/F/op/api/v2",
-      "path_to_root": "_dependentPackages/CommonPlugins",
+      "id": "Microsoft.DocAsCode.MAML2Yaml",
+      "nuget_feed": "https://www.myget.org/F/op-dev/api/v2",
+      "path_to_root": "_dependentPackages/MAML2Yaml",
       "target_framework": "net45",
-      "version": "latest"
+      "version": "latest-prerelease"
     }
   ],
   "branch_target_mapping": {

--- a/docfx.json
+++ b/docfx.json
@@ -26,7 +26,7 @@
       },
       {
         "files": [
-          "**/*.md"
+          "**/*.yml"
         ],
         "src": "partnercenterps-1.5",
         "version": "partnercenterps-1.5",
@@ -62,7 +62,7 @@
       },
       {
         "files": [
-          "**/*.md"
+          "**/*.yml"
         ],
         "src": "partnercenterps-2.0",
         "version": "partnercenterps-2.0",
@@ -98,7 +98,7 @@
       },
       {
         "files": [
-          "**/*.md"
+          "**/*.yml"
         ],
         "src": "partnercenterps-3.0",
         "version": "partnercenterps-3.0",
@@ -142,16 +142,16 @@
     },
     "filemetadata": {
       "enable_powershell_try_it": {
-        "partnercenterps-*/**/*.md": false
+        "partnercenterps-*/**/*.yml": false
       },
       "ms.date": {
-        "partnercenterps-1.5/**/*.md": "12/19/2019",
-        "partnercenterps-2.0/**/*.md": "01/10/2020",
-        "partnercenterps-3.0/**/*.md": "01/29/2020"
+        "partnercenterps-1.5/**/*.yml": "12/19/2019",
+        "partnercenterps-2.0/**/*.yml": "01/10/2020",
+        "partnercenterps-3.0/**/*.yml": "01/29/2020"
       },
       "ms.topic": {
-        "docs-conceptual/**/*.md": "article",
-        "partnercenterps-*/**/*.md": "reference"
+        "docs-conceptual/**/*.yml": "article",
+        "partnercenterps-*/**/*.yml": "reference"
       }
     },
     "globalMetadata": {

--- a/docfx.json
+++ b/docfx.json
@@ -31,6 +31,7 @@
         "src": "partnercenterps-1.5",
         "version": "partnercenterps-1.5",
         "exclude": [
+          "toc.yml",
           "docs-conceptual/**"
         ],
         "dest": "module"
@@ -67,6 +68,7 @@
         "src": "partnercenterps-2.0",
         "version": "partnercenterps-2.0",
         "exclude": [
+          "toc.yml",
           "docs-conceptual/**"
         ],
         "dest": "module"
@@ -103,6 +105,7 @@
         "src": "partnercenterps-3.0",
         "version": "partnercenterps-3.0",
         "exclude": [
+          "toc.yml",
           "docs-conceptual/**"
         ],
         "dest": "module"

--- a/docfx.json
+++ b/docfx.json
@@ -150,7 +150,7 @@
         "partnercenterps-3.0/**/*.yml": "01/29/2020"
       },
       "ms.topic": {
-        "docs-conceptual/**/*.yml": "article",
+        "docs-conceptual/**/*.md": "article",
         "partnercenterps-*/**/*.yml": "reference"
       }
     },


### PR DESCRIPTION
These changes are intended to replace the legacy build pipeline with the new SDP build pipeline, which is the prerequisite to switch to DocFX v3. 

Related work item:
https://ceapex.visualstudio.com/Engineering/_workitems/edit/248659