### PR TITLE
Update secure-app-model.md

### DIFF
--- a/docs-conceptual/partnercenterps-1.5/secure-app-model.md
+++ b/docs-conceptual/partnercenterps-1.5/secure-app-model.md
@@ -160,7 +160,7 @@ $credential = Get-Credential
 $tenantId = '<Your Tenant Id>'
 $pcToken = New-PartnerAccessToken -RefreshToken $refreshToken -Resource https://api.partnercenter.microsoft.com -Credential $credential -TenantId $tenantId
 
-Connect-PartnerCenter -AccessToken $pcToken.AccessToken -ApplicationId $appId -TenantId $tenantId
+Connect-PartnerCenter -AccessToken $pcToken.AccessToken -TenantId $tenantId
 ```
 
 When you are prompted for credentials specify the application identifier and application secret, for the Azure AD application used when generating the refresh token.


### PR DESCRIPTION
The 'Using the Refresh Token' section is incorrect with its parameter use. Ref https://docs.microsoft.com/en-us/powershell/module/partnercenter/connect-partnercenter?view=partnercenterps-3.0

When using the AccessToken parameter, the ApplicationId should not be used. They are part of different parameter sets and will error out. In the example provided, either the ApplicationId should be removed, or the RefreshToken parameter should be used together with the ApplicationId parameter.